### PR TITLE
Connection to 2 databases for SQL data_extraction

### DIFF
--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr]
+    branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr, connection_to_2_databases]
   pull_request:
     branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr]
 

--- a/.github/workflows/check-release.yaml
+++ b/.github/workflows/check-release.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr, connection_to_2_databases]
+    branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr]
   pull_request:
     branches: [main, development, 6-issue-when-the-position-is-on-the-grid-line-in-lat_lon_cwp_manipulationr]
 

--- a/R/data_extraction.R
+++ b/R/data_extraction.R
@@ -41,11 +41,11 @@ data_extraction <- function(type,
     if (length(database_connection) == 2 && !is.list(database_connection[[2]])) {
       # Specific argument verification for simple database
       if (paste0(class(x = database_connection[[2]]),
-                 collapse = " ") != "PostgreSQLConnection" && paste0(class(x = database_connection[[2]]),
+                 collapse = " ") != "PqConnection" && paste0(class(x = database_connection[[2]]),
                                                                      collapse = " ") != "JDBCConnection") {
         stop(format(x = Sys.time(),
                     format = "%Y-%m-%d %H:%M:%S"),
-             " - Invalid \"database_connection\" argument. Class \"PostgreSQLConnection\" or \"JDBCConnection\" expected for the second element of the connection")
+             " - Invalid \"database_connection\" argument. Class \"PqConnection\" or \"JDBCConnection\" expected for the second element of the connection")
       }
     } else {
       # Specific argument verification for multiple database
@@ -54,11 +54,11 @@ data_extraction <- function(type,
                                 length = 2L,
                                 type = "list")
         if (paste0(class(x = database_connection[[number_database_connection]][[2]]),
-                   collapse = " ") != "PostgreSQLConnection" && paste0(class(x = database_connection[[number_database_connection]][[2]]),
+                   collapse = " ") != "PqConnection" && paste0(class(x = database_connection[[number_database_connection]][[2]]),
                                                                        collapse = " ") != "JDBCConnection") {
           stop(format(x = Sys.time(),
                       format = "%Y-%m-%d %H:%M:%S"),
-               " - Invalid \"database_connection\" argument. Class \"PostgreSQLConnection\" or \"JDBCConnection\" expected for the second element of the connection number ", number_database_connection)
+               " - Invalid \"database_connection\" argument. Class \"PqConnection\" or \"JDBCConnection\" expected for the second element of the connection number ", number_database_connection)
         }
       }
     }

--- a/man/data_extraction.Rd
+++ b/man/data_extraction.Rd
@@ -19,7 +19,7 @@ data_extraction(
 
 \item{file_path}{{\link[base]{character}} expected. Mandatory. File path of the csv, txt or sql file.}
 
-\item{database_connection}{{\link[base]{list}} expected. Mandatory for type "sql". By default NULL. Output list from the furdeb database connection functions (like {\link[furdeb]{access_dbconnection}} or {\link[furdeb]{postgresql_dbconnection}}).}
+\item{database_connection}{{\link[base]{list}} expected. Mandatory for type "sql". By default NULL. Output list of furdeb connection functions to one or more databases (like {\link[furdeb]{access_dbconnection}} or {\link[furdeb]{postgresql_dbconnection}}).}
 
 \item{anchor}{{\link[base]{list}} expected. Optional for type "sql". By default NULL. List of values to interpolate in a SQL string query. Each list element have to follow this format: name_anchor = values. Be aware that the values typing format influence the writing of the sql in the query. For example, an integer or numeric value doesn't have any quote, rather than a date or string value.}
 


### PR DESCRIPTION
Add connection to 2 or more databases in data_extraction for SQL.
The use of a single database is still possible, as previously with :
database_connection = furdeb::postgresql_dbconnection(
            db_user = config_observe[["databases_configuration"]][["database1"]][["login"]],
            db_password = config_observe[["databases_configuration"]][["database1"]][["password"]],
            db_dbname = config_observe[["databases_configuration"]][["database1"]][["dbname"]],
            db_host = config_observe[["databases_configuration"]][["database1"]][["host"]],
            db_port = config_observe[["databases_configuration"]][["database1"]][["port"]]
          )
But it is now possible to provide it with several databases to have all the extractions grouped together :
database_connection = list(furdeb::postgresql_dbconnection(
            db_user = config_observe[["databases_configuration"]][["database1"]][["login"]],
            db_password = config_observe[["databases_configuration"]][["database1"]][["password"]],
            db_dbname = config_observe[["databases_configuration"]][["database1"]][["dbname"]],
            db_host = config_observe[["databases_configuration"]][["database1"]][["host"]],
            db_port = config_observe[["databases_configuration"]][["database1"]][["port"]]
          ),furdeb::postgresql_dbconnection(
            db_user = config_observe[["databases_configuration"]][["database2"]][["login"]],
            db_password = config_observe[["databases_configuration"]][["database2"]][["password"]],
            db_dbname = config_observe[["databases_configuration"]][["database2"]][["dbname"]],
            db_host = config_observe[["databases_configuration"]][["database2"]][["host"]],
            db_port = config_observe[["databases_configuration"]][["database2"]][["port"]]
          ))